### PR TITLE
Fix python3

### DIFF
--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -1,4 +1,4 @@
-from vraapiclient import catalog
+from vraapiclient import catalog  # pylint: disable=no-name-in-module
 from st2common.runners.base_action import Action
 
 

--- a/vra7config.py
+++ b/vra7config.py
@@ -41,12 +41,11 @@ p = subprocess.Popen(["st2", "key", "set", "vra7_password", p1, "--encrypt"],
                      stdout=subprocess.PIPE)
 cmdoutput, err = p.communicate()
 
-config = open(configfile, 'w')
-config.write("hostname: " + '"' + str(hostname) + '"' + "\n")
-config.write("username: " + '"' + str(username) + '"' + "\n")
-config.write('password: "{{st2kv.system.vra7_password}}"' + "\n")
-config.write("tenant: " + '"' + str(tenantvalue) + '"' + "\n")
-config.write("verify_ssl: " + str(verifyssl) + "\n")
-config.close()
+with open(configfile, 'w') as config:
+    config.write("hostname: " + '"' + str(hostname) + '"' + "\n")
+    config.write("username: " + '"' + str(username) + '"' + "\n")
+    config.write('password: "{{st2kv.system.vra7_password}}"' + "\n")
+    config.write("tenant: " + '"' + str(tenantvalue) + '"' + "\n")
+    config.write("verify_ssl: " + str(verifyssl) + "\n")
 
 print("Successfully configured vRA7 integration pack")

--- a/vra7config.py
+++ b/vra7config.py
@@ -6,15 +6,20 @@ from __future__ import print_function
 import getpass
 import subprocess
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
 configfile = '/opt/stackstorm/configs/vra7.yaml'
 
-hostname = raw_input("hostname (vRA FQDN ex. cloud.company.local): ")
+hostname = input("hostname (vRA FQDN ex. cloud.company.local): ")
 
 # vRA SSl certification verification configuration
-verifyssl = raw_input("verify vRA SSL certificate (true/false) [false]: ")
+verifyssl = input("verify vRA SSL certificate (true/false) [false]: ")
 verifysslvalue = verifyssl or 'vsphere.local'
 
-username = raw_input("username: ")
+username = input("username: ")
 
 
 def pprompt():
@@ -29,7 +34,7 @@ while p1 != p2:
     p1, p2 = pprompt()
 
 # vRA tenant configuration
-tenant = raw_input("tenant name [vsphere.local]: ")
+tenant = input("tenant name [vsphere.local]: ")
 tenantvalue = tenant or 'vsphere.local'
 
 p = subprocess.Popen(["st2", "key", "set", "vra7_password", p1, "--encrypt"],


### PR DESCRIPTION
Fix usage of `raw_input`, use a context manager to open and write to a file, and disable a spurious pylint error.

The [`catalog.py` module](https://github.com/chelnak/vRAAPIClient/blob/master/vraapiclient/catalog.py) definitely still exists, but I think pylint is getting confused because that module is not imported by the [`__init__.py` module](https://github.com/chelnak/vRAAPIClient/blob/master/vraapiclient/__init__.py). Luckily, the way Python packages work, this works just fine:

```python
from vraapiclient import catalog
```